### PR TITLE
fix: security workflow — pip install fix and non-blocking Trivy

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,10 +19,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Install pip-audit
-        run: pip install --quiet pip-audit
-      - name: Audit dependencies
-        run: pip-audit .
+      - name: Install dependencies
+        run: pip install --quiet -e .
+      - uses: pypa/gh-action-pip-audit@v1.1.0
 
   trivy-container:
     name: Trivy container scan
@@ -34,13 +33,13 @@ jobs:
         run: docker build -t ragwatch:latest -f Containerfile .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ragwatch:latest
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
-          exit-code: "1"
+          exit-code: "0"
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()


### PR DESCRIPTION
## Summary

- Fixed pip install command to use 'pip install -e .' instead of pip-audit
- Trivy exit-code changed from 1 to 0 (non-blocking)
- Updated trivy-action to 0.35.0