### PR TITLE
fix(ragwatch): use standard setuptools.build_meta backend and add explicit package discovery (fixes #11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ dev = [
 
 [build-system]
 requires = ["setuptools>=68"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["ragwatch"]
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
Closes #11

## Problem
PR #10 was failing CI because:
1. `pyproject.toml` used the legacy setuptools build backend `setuptools.backends._legacy:_Backend` which is an internal API no longer importable in modern setuptools versions. Error: `BackendUnavailable: Cannot import 'setuptools.backends._legacy'`
2. No explicit package discovery was configured, causing editable installs to fail.

## Solution
1. Changed `build-backend` from `setuptools.backends._legacy:_Backend` to `setuptools.build_meta` — the standard, supported build backend.
2. Added `[tool.setuptools] packages = ["ragwatch"]` for explicit package discovery.

## Testing
- 10 tests pass
- `pip install -e '.[dev]'` succeeds
- `ruff check .` and `ruff format --check .` pass