### PR TITLE
fix(ci): add file: Containerfile to build-push-action (refs rag-suite#10)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -58,6 +58,7 @@ jobs:
         uses: docker/build-push-action@v7.0.0
         with:
           context: .
+          file: Containerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Closes rag-suite#10

## Problem
The CI workflow's `build-push-action` step did not specify `file: Containerfile`, causing it to default to looking for `Dockerfile`. Since the repository uses `Containerfile` (Podman convention), the build failed with:

```
ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

## Fix
Added `file: Containerfile` to the build-push-action step, matching the hadolint step which already correctly specified the file.

## Testing
YAML validated successfully.